### PR TITLE
Fix/xaml public constructors

### DIFF
--- a/src/Ryujinx/UI/Applet/ProfileSelectorDialog.axaml.cs
+++ b/src/Ryujinx/UI/Applet/ProfileSelectorDialog.axaml.cs
@@ -17,10 +17,20 @@ namespace Ryujinx.Ava.UI.Applet
 {
     public partial class ProfileSelectorDialog : RyujinxControl<ProfileSelectorDialogViewModel>
     {
+        /// <summary>
+        /// Parameterless constructor required for XAML runtime instantiation.
+        /// </summary>
+        public ProfileSelectorDialog() : this(new ProfileSelectorDialogViewModel())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ProfileSelectorDialog with the specified view model.
+        /// </summary>
+        /// <param name="viewModel">The view model to use as the DataContext.</param>
         public ProfileSelectorDialog(ProfileSelectorDialogViewModel viewModel)
         {
             DataContext = ViewModel = viewModel;
-            
             InitializeComponent();
         }
         
@@ -53,13 +63,13 @@ namespace Ryujinx.Ava.UI.Applet
                         ViewModel.SelectedUserId = userProfile.UserId;
                         Logger.Info?.Print(LogClass.UI, $"Selected: {userProfile.UserId}", "ProfileSelector");
 
-                        ObservableCollection<BaseModel> newProfiles = [];
+                        ObservableCollection<BaseModel> newProfiles = new ObservableCollection<BaseModel>();
 
                         foreach (BaseModel item in ViewModel.Profiles)
                         {
                             if (item is UserProfile originalItem)
                             {
-                                UserProfileSft profile = new(originalItem.UserId, originalItem.Name, originalItem.Image);
+                                UserProfileSft profile = new UserProfileSft(originalItem.UserId, originalItem.Name, originalItem.Image);
                                 
                                 if (profile.UserId == ViewModel.SelectedUserId)
                                 {
@@ -78,7 +88,7 @@ namespace Ryujinx.Ava.UI.Applet
 
         public static async Task<(UserId Id, bool Result)> ShowInputDialog(ProfileSelectorDialogViewModel viewModel)
         {
-            ContentDialog contentDialog = new()
+            ContentDialog contentDialog = new ContentDialog
             {
                 Title = LocaleManager.Instance[LocaleKeys.UserProfileWindowTitle],
                 PrimaryButtonText = LocaleManager.Instance[LocaleKeys.Continue],

--- a/src/Ryujinx/UI/Windows/GameSpecificSettingsWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/GameSpecificSettingsWindow.axaml.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         protected override void OnClosing(WindowClosingEventArgs e)
         {
-            InputPage.Dispose();
+            InputPage.Dispose(); // You need to unload the gamepad settings, otherwise the controls will be blocked
             base.OnClosing(e);
         }
     }

--- a/src/Ryujinx/UI/Windows/GameSpecificSettingsWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/GameSpecificSettingsWindow.axaml.cs
@@ -5,13 +5,25 @@ using Ryujinx.Ava.UI.ViewModels;
 using System;
 using System.Linq;
 
-
 namespace Ryujinx.Ava.UI.Windows
 {
     public partial class GameSpecificSettingsWindow : StyleableAppWindow
     {
         internal readonly SettingsViewModel ViewModel;
 
+        /// <summary>
+        /// Parameterless constructor required for XAML runtime instantiation.
+        /// Creates a default MainWindowViewModel instance.
+        /// </summary>
+        public GameSpecificSettingsWindow() : this(new MainWindowViewModel(), true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of GameSpecificSettingsWindow.
+        /// </summary>
+        /// <param name="viewModel">The main window view model.</param>
+        /// <param name="findUserConfigDir">Indicates whether to find the user configuration directory.</param>
         public GameSpecificSettingsWindow(MainWindowViewModel viewModel, bool findUserConfigDir = true)
         {
             Title = string.Format(LocaleManager.Instance[LocaleKeys.SettingsWithInfo], viewModel.SelectedApplication.Name, viewModel.SelectedApplication.IdString);
@@ -38,7 +50,6 @@ namespace Ryujinx.Ava.UI.Windows
             InputPage.InputView?.SaveCurrentProfile();
         }
 
-
         private void Load()
         {
             Pages.Children.Clear();
@@ -48,7 +59,6 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void NavPanelOnSelectionChanged(object sender, NavigationViewSelectionChangedEventArgs e)
         {
-            
             if (e.SelectedItem is NavigationViewItem navItem && navItem.Tag is not null)
             {
                 switch (navItem.Tag.ToString())
@@ -92,7 +102,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         protected override void OnClosing(WindowClosingEventArgs e)
         {
-            InputPage.Dispose(); // You need to unload the gamepad settings, otherwise the controls will be blocked
+            InputPage.Dispose();
             base.OnClosing(e);
         }
     }


### PR DESCRIPTION
fix(UI): Add public parameterless constructors to XAML code-behind classes

- ProfileSelectorDialog.axaml.cs: Added a public parameterless constructor for runtime XAML instantiation.
- GameSpecificSettingsWindow.axaml.cs: Added a public parameterless constructor, creating a default MainWindowViewModel.

These changes ensure that Avalonia's runtime loader can instantiate the controls via XAML.