### PR TITLE
fix: add parameterless constructor to ProfileSelectorDialog

### DIFF
--- a/src/Ryujinx/UI/Applet/ProfileSelectorDialog.axaml.cs
+++ b/src/Ryujinx/UI/Applet/ProfileSelectorDialog.axaml.cs
@@ -17,10 +17,14 @@ namespace Ryujinx.Ava.UI.Applet
 {
     public partial class ProfileSelectorDialog : RyujinxControl<ProfileSelectorDialogViewModel>
     {
+        // Parameterless constructor needed for Avalonia's runtime loader.
+        public ProfileSelectorDialog() : this(new ProfileSelectorDialogViewModel())
+        {
+        }
+
         public ProfileSelectorDialog(ProfileSelectorDialogViewModel viewModel)
         {
             DataContext = ViewModel = viewModel;
-            
             InitializeComponent();
         }
         
@@ -53,7 +57,7 @@ namespace Ryujinx.Ava.UI.Applet
                         ViewModel.SelectedUserId = userProfile.UserId;
                         Logger.Info?.Print(LogClass.UI, $"Selected: {userProfile.UserId}", "ProfileSelector");
 
-                        ObservableCollection<BaseModel> newProfiles = [];
+                        ObservableCollection<BaseModel> newProfiles = new ObservableCollection<BaseModel>();
 
                         foreach (BaseModel item in ViewModel.Profiles)
                         {


### PR DESCRIPTION
fix: add parameterless constructor to ProfileSelectorDialog

This fix adds a public parameterless constructor to the ProfileSelectorDialog,
allowing Avalonia's runtime loader to instantiate the control without errors.
